### PR TITLE
Make cache working

### DIFF
--- a/modules/plug_example/plug_example.module
+++ b/modules/plug_example/plug_example.module
@@ -27,7 +27,7 @@ function plug_example_test_page() {
   $namespaces = new \ArrayObject(array(
     'Drupal\plug_example' => drupal_get_path('module', 'plug_example') . '/src',
   ));
-  $manager = new Drupal\plug_example\NamePluginManager($namespaces, new \DrupalDatabaseCache('name'));
+  $manager = new Drupal\plug_example\NamePluginManager($namespaces, new \DrupalDatabaseCache('cache'));
   $output = array();
   foreach ($manager->getDefinitions() as $id => $plugin) {
     // This is just a silly way to show how you can pass arbitrary configuration

--- a/modules/plug_example/src/Plugin/name/Mom.php
+++ b/modules/plug_example/src/Plugin/name/Mom.php
@@ -2,16 +2,16 @@
 
 /**
  * @file
- * Contains Drupal\pugins_example\Plugin\name\Mom
+ * Contains Drupal\plug_example\Plugin\name\Mom
  */
 
 namespace Drupal\plug_example\Plugin\name;
 
 /**
  * Class Mom
- * @package Drupal\pugins_example\Plugins
+ * @package Drupal\plug_example\Plugins
  *
- * @Plugin(
+ * @Name(
  *   id = "mom",
  *   company = FALSE
  * )

--- a/src/Core/Plugin/DefaultPluginManager.php
+++ b/src/Core/Plugin/DefaultPluginManager.php
@@ -38,13 +38,6 @@ class DefaultPluginManager extends PluginManagerBase implements PluginManagerInt
   protected $cacheKey;
 
   /**
-   * An array of cache tags to use for the cached definitions.
-   *
-   * @var array
-   */
-  protected $cacheTags = array();
-
-  /**
    * Name of the alter hook if one should be invoked.
    *
    * @var string
@@ -162,7 +155,7 @@ class DefaultPluginManager extends PluginManagerBase implements PluginManagerInt
    */
   protected function setCachedDefinitions($definitions) {
     if ($this->cacheBackend) {
-      $this->cacheBackend->set($this->cacheKey, $definitions, CACHE_PERMANENT, $this->cacheTags);
+      $this->cacheBackend->set($this->cacheKey, $definitions, CACHE_PERMANENT);
     }
     $this->definitions = $definitions;
   }


### PR DESCRIPTION
Removing cacheTags property in DefautPluginManager (It's not available in D7)
Use the generic 'cache' bin in plug_example.module to make cache working
Add the Name annotation to Mom class
