### PR TITLE
Automatic Namespace generation

### DIFF
--- a/modules/plug_example/plug_example.module
+++ b/modules/plug_example/plug_example.module
@@ -5,6 +5,9 @@
  * Module implementation file.
  */
 
+use \Drupal\Core\Plugin\DefaultPluginManager;
+use \Drupal\plug_example\NamePluginManager;
+
 /**
  * Implements hook_menu().
  */
@@ -23,11 +26,7 @@ function plug_example_menu() {
  * Page callback to test the plugins.
  */
 function plug_example_test_page() {
-  // TODO: This $namespaces array should be generated automagically.
-  $namespaces = new \ArrayObject(array(
-    'Drupal\plug_example' => drupal_get_path('module', 'plug_example') . '/src',
-  ));
-  $manager = new Drupal\plug_example\NamePluginManager($namespaces, new \DrupalDatabaseCache('cache'));
+  $manager = new NamePluginManager(DefaultPluginManager::getNamespaces(), new \DrupalDatabaseCache('cache'));
   $output = array();
   foreach ($manager->getDefinitions() as $id => $plugin) {
     // This is just a silly way to show how you can pass arbitrary configuration

--- a/plug.info
+++ b/plug.info
@@ -3,4 +3,4 @@ description = A port of the D8 plugin system.
 core = 7.x
 php = 5.4.2
 dependencies[] = composer_manager
-dependencies[] = xautoload
+dependencies[] = xautoload (>= 7.x-5.0)

--- a/src/Core/Plugin/DefaultPluginManager.php
+++ b/src/Core/Plugin/DefaultPluginManager.php
@@ -204,4 +204,28 @@ class DefaultPluginManager extends PluginManagerBase implements PluginManagerInt
     return $definitions;
   }
 
+  /**
+   * Generates the array of available namespaces for plugins.
+   *
+   * @return \ArrayObject
+   *   The generated array of namespaces
+   */
+  public static function getNamespaces() {
+    $namespaces = &drupal_static(__FUNCTION__);
+    if (!isset($namespaces)) {
+      if ($cache = cache_get('plugin_namespaces')) {
+        $namespaces = $cache->data;
+      }
+      else {
+        $namespaces = array();
+        foreach (module_list() as $module) {
+          $namespaces['Drupal\\' . $module] = drupal_get_path('module', $module) . '/src';
+        }
+        $namespaces = new \ArrayObject($namespaces);
+        cache_set('plugin_namespaces', $namespaces);
+      }
+    }
+    return $namespaces;
+  }
+
 }


### PR DESCRIPTION
Added static method to DefaultPluginManager class to generate automatically the namespaces array.

What do you think about wrap all this together in a ::create() method instead of passing these arguments (cache and namespaces) in every call. I know, we are breaking in that case the dependency injection, but in 90% of the cases, that will be the usage.
