### PR TITLE
Clean hook_fruit_plugin_alter() implementation

### DIFF
--- a/modules/plug_example/plug_example.module
+++ b/modules/plug_example/plug_example.module
@@ -42,14 +42,15 @@ function plug_example_menu() {
  * Adds a new fruit plugin programmatically.
  */
 function plug_example_fruit_plugin_alter(&$plugins) {
-  $plugins['banana'] = array(
+  $plugin_manager = FruitPluginManager::create();
+  $base_definition = array(
     'label' => 'Banana',
     'sugar' => 'medium',
-    'slimy' => FALSE,
     'id' => 'banana',
     'provider' => 'plug_example',
-    'class' => 'Drupal\plug_example\Plugin\fruit\Fruit',
   );
+  $plugin_manager->processDefinition($base_definition);
+  $plugins[$base_definition['id']] = $base_definition;
 }
 
 /**

--- a/src/Core/Plugin/DefaultPluginManager.php
+++ b/src/Core/Plugin/DefaultPluginManager.php
@@ -168,7 +168,7 @@ class DefaultPluginManager extends PluginManagerBase implements PluginManagerInt
    * additional processing logic they can do that by replacing or extending the
    * method.
    */
-  public function processDefinition(&$definition, $plugin_id) {
+  public function processDefinition(&$definition) {
     if (!empty($this->defaults) && is_array($this->defaults)) {
       $definition = drupal_array_merge_deep($this->defaults, $definition);
     }


### PR DESCRIPTION
Use DefaultPluginManager::processDefinition() instead of hardcoding all the definition array. Useful in more complex implementations.
Removed unused $plugin_id parameter in DefaultPluginManager::processDefinition()
