### PR TITLE
[BUGFIX] Update the PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/plug.info
+++ b/plug.info
@@ -1,7 +1,7 @@
 name = Plug
 description = A port of the D8 plugin system.
 core = 7.x
-php = 5.4.2
+php = 5.5.9
 package = Plug
 dependencies[] = registry_autoload
 


### PR DESCRIPTION
Drupal 8 requires PHP 5.5.9. So do their components then.
