### PR TITLE
Save result in memory when successfully pulled from database

### DIFF
--- a/src/Util/Module.php
+++ b/src/Util/Module.php
@@ -59,7 +59,8 @@ class Module {
       return $data;
     }
     if ($cache = cache_get($cache_name)) {
-      return $cache->data;
+      $data = $cache->data;
+      return $data;
     }
     $data = call_user_func_array(array(get_called_class(), $method_name), array());
     cache_set($cache_name, $data);


### PR DESCRIPTION
I found this issue while investigating a system built with this and restful. The memoize method was getting called a lot and because it wasn't saving results in memory it was resulting in many (thousands) of duplicate database calls per page load. This change just caches a db cache hit in memory for the rest of the request.
